### PR TITLE
[SECURITY] Add Codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+SECURITY.md @CSGY-9223-Group2/security
+LICENSE.md @CSGY-9223-Group2/security
+
+*.py @CSGY-9223-Group2/engineering


### PR DESCRIPTION
- This can be expanded and tweaked as we progress, but this can become beneficial for branch protection rules to enforce required reviewers.