### PR TITLE
[Docs] Add additional context to the security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,12 @@
-initial SECURITY.md
+# Reporting Security Issues
+
+The team and community take security bugs in this project seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/CSGY-9223-Group2/lab_one/security/advisories/new) tab.
+
+The team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining the module.
+
+## Contact Us
+For direct points of contact, please contact a member of the ["CSGY-9223-Group2 Security Team"](https://github.com/orgs/CSGY-9223-Group2/teams/security)


### PR DESCRIPTION
Create a base Security policy, based on the example provided by GitHub references.

Refs:
https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository

https://github.com/electron/electron/blob/main/SECURITY.md