### PR TITLE
Docker Security Changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-slim
+RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 WORKDIR /app
 
 COPY requirements.txt requirements.txt
@@ -8,6 +9,8 @@ RUN apt-get update && apt-get install -y openssl
 RUN API_KEY=$(openssl rand -hex 16) && echo "API_KEY=$API_KEY" >> /etc/environment
 
 COPY app.py app.py
+RUN chown -R appuser:appgroup /app
+USER appuser
 
 EXPOSE 5000
 CMD ["sh", "-c", "API_KEY=$(openssl rand -hex 16) && export API_KEY=$API_KEY && python3 -m flask run --host=0.0.0.0"]

--- a/app.py
+++ b/app.py
@@ -222,4 +222,4 @@ def login():
 
 if __name__ == '__main__':
     
-    app.run(debug=True)
+    app.run(debug=False)

--- a/app.py
+++ b/app.py
@@ -21,11 +21,6 @@ db = SQLAlchemy(app)
 bcrypt = Bcrypt(app)
 SECRET_KEY = app.config['SECRET_KEY']
 
-# Directory to store paste files
-PASTE_DIR = 'pastes'
-if not os.path.exists(PASTE_DIR):
-    os.makedirs(PASTE_DIR)
-
 # User model
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$(docker ps -q -f name=pastebin_container)" ]; then
+if [ "$(docker ps -a -q -f name=pastebin_container)" ]; then
     echo "Stopping and removing existing container..."
     docker stop pastebin_container
     docker rm pastebin_container
@@ -10,6 +10,6 @@ echo "Building Docker image..."
 docker build -t pastebin_app .
 
 echo "Running Docker container..."
-docker run -d -p 5000:5000 --cap-drop=ALL --cap-add=NET_BIND_SERVICE --name pastebin_container pastebin_app
+docker run -d -p 5000:5000 --security-opt=no-new-privileges --cap-drop=ALL --cap-add=NET_BIND_SERVICE --name pastebin_container pastebin_app
 
 echo "Docker container is up and running."

--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if ! docker network ls | grep -q pastebin_iso_network; then
+    echo "Creating pastebin isolated Docker Network..."
+    docker network create pastebin_iso_network
+else
+    echo "Docker network 'pastebin_iso_network' already exists."
+fi
+
+
 if [ "$(docker ps -a -q -f name=pastebin_container)" ]; then
     echo "Stopping and removing existing container..."
     docker stop pastebin_container
@@ -11,6 +19,7 @@ docker build -t pastebin_app .
 
 echo "Running Docker container..."
 docker run -d -p 5000:5000 \
+    --network=pastebin_iso_network \
     --read-only \
     --tmpfs /app/instance \
     --security-opt=no-new-privileges \

--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -10,6 +10,13 @@ echo "Building Docker image..."
 docker build -t pastebin_app .
 
 echo "Running Docker container..."
-docker run -d -p 5000:5000 --security-opt=no-new-privileges --cap-drop=ALL --cap-add=NET_BIND_SERVICE --name pastebin_container pastebin_app
+docker run -d -p 5000:5000 \
+    --read-only \
+    --tmpfs /app/instance \
+    --security-opt=no-new-privileges \
+    --cap-drop=ALL \
+    --cap-add=NET_BIND_SERVICE \
+    --name pastebin_container \
+    pastebin_app
 
 echo "Docker container is up and running."

--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -10,6 +10,6 @@ echo "Building Docker image..."
 docker build -t pastebin_app .
 
 echo "Running Docker container..."
-docker run -d -p 5000:5000 --name pastebin_container pastebin_app
+docker run -d -p 5000:5000 --cap-drop=ALL --cap-add=NET_BIND_SERVICE --name pastebin_container pastebin_app
 
 echo "Docker container is up and running."


### PR DESCRIPTION
This patch introduces several changes to the Docker image and container creation process. Below is a list of each of these changes:

    Non-root user is used to run applications with in the container
    Linux kernel services have been reduced to just NET_BIND_SERVICE
    Added prevention for in-container privilege escalation
    File system has been set to read-only with the exception of the instances folder
    Added a network, pastebin_iso_network, to isolate the docker container from other containers on the default docker network

Additionally, this patch removes a portion of the code that creates a PASTES directory. This is not needed anymore, as the app stores pastes content into the sqlite database.
