### PR TITLE
Grant Execute Permissions in Docker Action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,7 +19,10 @@ jobs:
 
     - name: Run Docker Setup Script
       run: ./docker_setup.sh
-
+      
+    - name: Grant execute permission for the docker setup script
+      run: chmod +x ./docker_setup.sh
+      
     - name: Run Trivy Vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:


### PR DESCRIPTION
docker_setup.sh is given execution privileges. This is need so that the action can correctly run.