### PR TITLE
Secret Key Unit Tests Fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+
 
 jobs:
   test:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2,6 +2,7 @@ import pytest
 from app import app, db, User, Paste, bcrypt
 import jwt
 import datetime
+import os
 
 @pytest.fixture
 def client():
@@ -22,6 +23,11 @@ def generate_test_token(user_id):
     }
     token = jwt.encode(payload, app.config['SECRET_KEY'], algorithm='HS256')
     return token
+
+def test_secret_key():
+    with app.app_context():
+        assert app.config['SECRET_KEY'] == os.getenv('API_KEY')
+    print("secret_key is pulled from environment")
 
 def test_register_route(client):
     response = client.post('/register', json={


### PR DESCRIPTION
This patch makes fixes the issue that our unit tests was not properly making sure that the secret key that was being used was the key that was being used for the docker environment. This will guard against hardcoded secret keys, or secret keys that could be retrieved from a malicious source.

It also applies the workflow_dispatch to the python unit tests so that the unit tests action can be run manually on other brancehs.